### PR TITLE
Remove unused unsafe blocks

### DIFF
--- a/minion-cli/src/main.rs
+++ b/minion-cli/src/main.rs
@@ -155,9 +155,9 @@ async fn main() {
             .collect(),
         sandbox: sandbox.clone(),
         stdio: minion::StdioSpecification {
-            stdin: unsafe { minion::InputSpecification::handle(stdin_fd) },
-            stdout: unsafe { minion::OutputSpecification::handle(stdout_fd) },
-            stderr: unsafe { minion::OutputSpecification::handle(stderr_fd) },
+            stdin: minion::InputSpecification::handle(stdin_fd),
+            stdout: minion::OutputSpecification::handle(stdout_fd),
+            stderr: minion::OutputSpecification::handle(stderr_fd),
         },
         pwd: options.pwd.into(),
     };

--- a/minion-ffi/src/lib.rs
+++ b/minion-ffi/src/lib.rs
@@ -305,12 +305,10 @@ pub unsafe extern "C" fn minion_cp_spawn(
             p = p.offset(1);
         }
     }
-    let stdio = unsafe {
-        minion::StdioSpecification {
-            stdin: minion::InputSpecification::handle(options.stdio.stdin),
-            stdout: minion::OutputSpecification::handle(options.stdio.stdout),
-            stderr: minion::OutputSpecification::handle(options.stdio.stderr),
-        }
+    let stdio = minion::StdioSpecification {
+        stdin: minion::InputSpecification::handle(options.stdio.stdin),
+        stdout: minion::OutputSpecification::handle(options.stdio.stdout),
+        stderr: minion::OutputSpecification::handle(options.stdio.stderr),
     };
     let options = unsafe {
         minion::ChildProcessOptions {


### PR DESCRIPTION
They are redundant after recent chanes to minion core.