### PR TITLE
Rewrite cgroup detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,15 +143,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
-dependencies = [
- "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -289,16 +274,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-
-[[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -311,24 +290,6 @@ name = "libc"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
-
-[[package]]
-name = "libflate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bac9023e1db29c084f9f8cd9d3852e5e8fddf98fb47c4964a0ea4663d95949"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
 name = "log"
@@ -369,10 +330,10 @@ dependencies = [
  "backtrace",
  "errno",
  "futures-util",
+ "itoa",
  "libc",
  "nix 0.19.0",
  "once_cell",
- "procfs",
  "rand",
  "serde",
  "serde_json",
@@ -625,21 +586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c434e93ef69c216e68e4f417c927b4f31502c3560b72cfdb6827e2321c5c6b3e"
-dependencies = [
- "bitflags",
- "byteorder",
- "chrono",
- "hex",
- "lazy_static",
- "libc",
- "libflate",
-]
-
-[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,12 +683,6 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ rand = "0.7.3"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.51"
 tiny-nix-ipc = { git = "https://github.com/myfreeweb/tiny-nix-ipc", features = ["ser_json", "zero_copy"] }
-procfs = "0.7.8"
 nix = { version = "0.19.0" }
 backtrace = "0.3.46"
 thiserror = "1.0.19"
@@ -20,6 +19,7 @@ once_cell = "1.4.1"
 futures-util = "0.3.6"
 tokio = { version = "0.3.2", features = ["net"] }
 tracing = "0.1.22"
+itoa = "0.4.7"
 
 [workspace]
 members = ["minion-ffi", ".", "minion-tests", "minion-cli"]

--- a/src/check.rs
+++ b/src/check.rs
@@ -41,13 +41,13 @@ impl std::fmt::Display for CheckResult {
         if !self.errors.is_empty() {
             "Errors:\n".fmt(f)?;
             for err in &self.errors {
-                format_args!("\t{}", err).fmt(f)?;
+                format_args!("\t{}\n", err).fmt(f)?;
             }
         }
         if !self.warnings.is_empty() {
             "Warnings:\n".fmt(f)?;
             for warn in &self.warnings {
-                format_args!("\t{}", warn).fmt(f)?;
+                format_args!("\t{}\n", warn).fmt(f)?;
             }
         }
         Ok(())

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -207,7 +207,7 @@ fn spawn(mut options: ChildProcessOptions<LinuxSandbox>) -> Result<LinuxChildPro
 
 /// Allows some customization
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     /// All created cgroups will be children of specified group
     /// Default value is "/minion"

--- a/src/linux/cgroup/v1.rs
+++ b/src/linux/cgroup/v1.rs
@@ -1,35 +1,65 @@
 //! Implements Cgroup Driver for V1 cgroups
-use crate::linux::cgroup::ResourceLimits;
+use crate::linux::cgroup::{CgroupError, ResourceLimits};
 use std::os::unix::io::{IntoRawFd, RawFd};
 use std::path::PathBuf;
+
 impl super::Driver {
-    pub(super) fn setup_cgroups_v1(&self, limits: &ResourceLimits, cgroup_id: &str) -> Vec<RawFd> {
+    fn v1_write_file(
+        &self,
+        cgroup_id: &str,
+        subsys_name: &str,
+        file_name: &str,
+        num: u64,
+    ) -> Result<(), CgroupError> {
+        let path = self
+            .get_path_for_cgroup_legacy_subsystem(subsys_name, cgroup_id)
+            .join(file_name);
+        let mut buf = itoa::Buffer::new();
+        let data = buf.format(num);
+
+        std::fs::write(&path, data).map_err(|cause| CgroupError::Write { path, cause })
+    }
+
+    fn v1_read_file(
+        &self,
+        cgroup_id: &str,
+        subsys_name: &str,
+        file_name: &str,
+    ) -> Result<String, CgroupError> {
+        let path = self
+            .get_path_for_cgroup_legacy_subsystem(subsys_name, cgroup_id)
+            .join(file_name);
+
+        std::fs::read_to_string(&path).map_err(|cause| CgroupError::Read { path, cause })
+    }
+
+    fn v1_create_cgroup(&self, cgroup_id: &str, subsys_name: &str) -> Result<(), CgroupError> {
+        let path = self.get_path_for_cgroup_legacy_subsystem(subsys_name, cgroup_id);
+
+        std::fs::create_dir_all(&path).map_err(|cause| CgroupError::CreateCgroupDir { path, cause })
+    }
+
+    pub(super) fn setup_cgroups_v1(
+        &self,
+        limits: &ResourceLimits,
+        cgroup_id: &str,
+    ) -> Result<Vec<RawFd>, CgroupError> {
         // configure cpuacct subsystem
-        let cpuacct_cgroup_path = self.get_path_for_cgroup_legacy_subsystem("cpuacct", cgroup_id);
-        std::fs::create_dir_all(&cpuacct_cgroup_path).expect("failed to create cpuacct cgroup");
+        self.v1_create_cgroup(cgroup_id, "cpuacct")?;
 
         // configure pids subsystem
-        let pids_cgroup_path = self.get_path_for_cgroup_legacy_subsystem("pids", cgroup_id);
-        std::fs::create_dir_all(&pids_cgroup_path).expect("failed to create pids cgroup");
-
-        std::fs::write(
-            pids_cgroup_path.join("pids.max"),
-            format!("{}", limits.pids_max),
-        )
-        .expect("failed to enable pids limit");
+        self.v1_create_cgroup(cgroup_id, "pids")?;
+        self.v1_write_file(cgroup_id, "pids", "pids.max", limits.pids_max.into())?;
 
         // configure memory subsystem
-        let mem_cgroup_path = self.get_path_for_cgroup_legacy_subsystem("memory", cgroup_id);
-
-        std::fs::create_dir_all(&mem_cgroup_path).expect("failed to create memory cgroup");
-        std::fs::write(mem_cgroup_path.join("memory.swappiness"), "0")
-            .expect("failed to disallow swapping");
-
-        std::fs::write(
-            mem_cgroup_path.join("memory.limit_in_bytes"),
-            format!("{}", limits.memory_max),
-        )
-        .expect("failed to enable memory limiy");
+        self.v1_create_cgroup(cgroup_id, "memory")?;
+        self.v1_write_file(cgroup_id, "memory", "memory.swappiness", 0)?;
+        self.v1_write_file(
+            cgroup_id,
+            "memory",
+            "memory.limit_in_bytes",
+            limits.memory_max,
+        )?;
 
         // we return handles to tasksfiles for main cgroups
         // so, though zygote itself and children are in chroot, and cannot access cgroupfs, they will be able to add themselves to cgroups
@@ -41,33 +71,29 @@ impl super::Driver {
                 let h = std::fs::OpenOptions::new()
                     .write(true)
                     .open(&p)
-                    .unwrap_or_else(|err| {
-                        panic!("Couldn't open tasks file {}: {}", p.display(), err)
-                    })
+                    .map_err(|cause| CgroupError::OpenFile { path: p, cause })?
                     .into_raw_fd();
-                nix::unistd::dup(h).expect("dup failed")
+                nix::unistd::dup(h).map_err(|cause| CgroupError::DuplicateFd { cause })
             })
-            .collect::<Vec<_>>()
+            .collect::<Result<Vec<_>, _>>()
     }
 
-    pub(super) fn get_memory_usage_v1(&self, cgroup_id: &str) -> u64 {
-        let mut current_usage_file = self.get_path_for_cgroup_legacy_subsystem("memory", cgroup_id);
-        current_usage_file.push("memory.max_usage_in_bytes");
-        std::fs::read_to_string(current_usage_file)
-            .expect("cannot read memory usage")
+    pub(super) fn get_memory_usage_v1(&self, cgroup_id: &str) -> Result<u64, CgroupError> {
+        let usage = self
+            .v1_read_file(cgroup_id, "memory", "memory.max_usage_in_bytes")?
             .trim()
-            .parse::<u64>()
-            .unwrap()
+            .parse()
+            .unwrap();
+        Ok(usage)
     }
 
-    pub(super) fn get_cpu_usage_v1(&self, cgroup_id: &str) -> u64 {
-        let current_usage_file = self.get_path_for_cgroup_legacy_subsystem("cpuacct", cgroup_id);
-        let current_usage_file = current_usage_file.join("cpuacct.usage");
-        std::fs::read_to_string(current_usage_file)
-            .expect("Couldn't load cpu usage")
+    pub(super) fn get_cpu_usage_v1(&self, cgroup_id: &str) -> Result<u64, CgroupError> {
+        let usage = self
+            .v1_read_file(cgroup_id, "cpuacct", "cpuacct.usage")?
             .trim()
-            .parse::<u64>()
-            .unwrap()
+            .parse()
+            .unwrap();
+        Ok(usage)
     }
 
     pub(super) fn drop_cgroup_v1(&self, cgroup_id: &str, subsystems: &[&str]) {

--- a/src/linux/cgroup/v2.rs
+++ b/src/linux/cgroup/v2.rs
@@ -1,60 +1,73 @@
 //! Implements Cgroup Driver for V2 cgroups
-use crate::linux::cgroup::{Driver, ResourceLimits};
+use crate::linux::cgroup::{CgroupError, Driver, ResourceLimits};
 use std::{
     os::unix::io::{IntoRawFd, RawFd},
     path::PathBuf,
 };
 
 impl Driver {
-    pub(super) fn setup_cgroups_v2(&self, limits: &ResourceLimits, cgroup_id: &str) -> RawFd {
-        let cgroup_path = self.get_path_for_cgroup_unified(cgroup_id);
-        std::fs::create_dir_all(&cgroup_path).expect("failed to create cgroup");
+    fn v2_write_file(&self, cgroup_id: &str, file_name: &str, num: u64) -> Result<(), CgroupError> {
+        let path = self.get_path_for_cgroup_unified(cgroup_id).join(file_name);
+        let mut buf = itoa::Buffer::new();
+        let data = buf.format(num);
 
+        std::fs::write(&path, data).map_err(|cause| CgroupError::Write { path, cause })
+    }
+
+    fn v2_read_file(&self, cgroup_id: &str, file_name: &str) -> Result<String, CgroupError> {
+        let path = self.get_path_for_cgroup_unified(cgroup_id).join(file_name);
+
+        std::fs::read_to_string(&path).map_err(|cause| CgroupError::Read { path, cause })
+    }
+
+    pub(super) fn setup_cgroups_v2(
+        &self,
+        limits: &ResourceLimits,
+        cgroup_id: &str,
+    ) -> Result<RawFd, CgroupError> {
+        let cgroup_path = self.get_path_for_cgroup_unified(cgroup_id);
+        std::fs::create_dir_all(&cgroup_path).map_err(|cause| CgroupError::CreateCgroupDir {
+            path: cgroup_path.clone(),
+            cause,
+        })?;
+
+        // TODO: should we ignore this error?
         std::fs::write(
             cgroup_path.parent().unwrap().join("cgroup.subtree_control"),
             "+pids +cpu +memory",
         )
         .ok();
 
-        std::fs::write(cgroup_path.join("pids.max"), format!("{}", limits.pids_max))
-            .expect("failed to set pids.max limit");
-
-        std::fs::write(
-            cgroup_path.join("memory.max"),
-            format!("{}", limits.memory_max),
-        )
-        .expect("failed to set memory limit");
+        self.v2_write_file(cgroup_id, "pids.max", limits.pids_max.into())?;
+        self.v2_write_file(cgroup_id, "memory.max", limits.memory_max)?;
 
         let tasks_file_path = cgroup_path.join("cgroup.procs");
         let h = std::fs::OpenOptions::new()
             .write(true)
             .open(&tasks_file_path)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Failed to open tasks file {}: {}",
-                    tasks_file_path.display(),
-                    err
-                )
-            });
-        nix::unistd::dup(h.into_raw_fd()).expect("dup failed")
+            .map_err(|cause| CgroupError::OpenFile {
+                path: tasks_file_path.clone(),
+                cause,
+            })?;
+        nix::unistd::dup(h.into_raw_fd()).map_err(|cause| CgroupError::DuplicateFd { cause })
     }
 
-    pub(super) fn get_cpu_usage_v2(&self, cgroup_id: &str) -> u64 {
-        let mut current_usage_file = self.get_path_for_cgroup_unified(cgroup_id);
-        current_usage_file.push("cpu.stat");
-        let stat_data =
-            std::fs::read_to_string(current_usage_file).expect("failed to read cpu.stat");
-        let mut val = 0;
+    pub(super) fn get_cpu_usage_v2(&self, cgroup_id: &str) -> Result<u64, CgroupError> {
+        let stat_data = self.v2_read_file(cgroup_id, "cpu.stat")?;
+        let mut val = u64::max_value();
         for line in stat_data.lines() {
             if line.starts_with("usage_usec") {
                 let usage = line
                     .trim_start_matches("usage_usec ")
                     .trim_end_matches('\n');
-                val = usage.parse().unwrap();
+                if let Ok(v) = usage.parse() {
+                    val = v;
+                    // multiply by 1000 to convert from microseconds to nanoseconds
+                    val *= 1000;
+                }
             }
         }
-        // multiply by 1000 to convert from microseconds to nanoseconds
-        val * 1000
+        Ok(val)
     }
 
     pub(super) fn drop_cgroup_v2(&self, cgroup_id: &str) {

--- a/src/linux/check.rs
+++ b/src/linux/check.rs
@@ -1,115 +1,12 @@
-use crate::linux::cgroup::CgroupVersion;
-use std::path::PathBuf;
-
-fn get_current_cgroup_path() -> Vec<String> {
-    let group = procfs::process::Process::myself()
-        .expect("failed to load myself data from procfs")
-        .cgroups()
-        .expect("/proc/self/cgroups is unreadable");
-    let first = group
-        .into_iter()
-        .next()
-        .expect("/proc/self/cgroups is empty");
-    assert!(!first.controllers.is_empty());
-    assert_eq!(first.hierarchy, 0);
-    let pathname = first.pathname;
-    pathname.split('/').map(ToString::to_string).collect()
-}
-
-fn get_sandbox_chgroup_path(settings: &crate::linux::Settings) -> Vec<String> {
-    settings
-        .cgroup_prefix
-        .to_str()
-        .unwrap()
-        .split('/')
-        .skip(1)
-        .map(ToString::to_string)
-        .collect()
-}
-
-fn check_has_cgroup_access(cgroup: &[String]) -> Result<(), String> {
-    let mut cgroup_path = PathBuf::from("/sys/fs/cgroup");
-    for item in cgroup {
-        cgroup_path.push(item);
-    }
-    let temp_dir_name = format!(
-        "jjs-minion-acc-ck-{}",
-        rand::random::<[char; 6]>().iter().collect::<String>()
-    );
-    let temp_dir_path = cgroup_path.join(temp_dir_name);
-    if let Err(err) = std::fs::create_dir(&temp_dir_path) {
-        return Err(format!("unable to create groups: {}", err));
-    }
-    if let Err(err) = std::fs::remove_dir(temp_dir_path) {
-        return Err(format!("failed to cleanup after check: {}", err));
-    }
-    let subtree_controllers = cgroup_path.join("cgroup.subtree_control");
-    let controllers = match std::fs::read_to_string(subtree_controllers) {
-        Ok(s) => s,
-        Err(err) => return Err(format!("failed to read enabled controllers: {}", err)),
-    };
-    let mut missing_controllers = Vec::new();
-    for &controller in &["pids", "memory", "cpu"] {
-        if !controllers.contains(controller) {
-            missing_controllers.push(controller);
-        }
-    }
-    if !missing_controllers.is_empty() {
-        return Err(format!(
-            "Required controllers are not enabled in cgroup.subtree_control: {:?}",
-            missing_controllers
-        ));
-    }
-    if let Err(err) = std::fs::write(cgroup_path.join("cgroup.procs"), "") {
-        return Err(format!("cgroup can not be joined or left: {}", err));
-    }
-    Ok(())
-}
-
-fn find_lca<'a>(a: &'a [String], b: &'a [String]) -> &'a [String] {
-    let n1 = a.len();
-    let n2 = b.len();
-    let n = std::cmp::min(n1, n2);
-
-    for i in 0..n {
-        if a[i] != b[i] {
-            return &a[..i];
-        }
-    }
-    if n1 < n2 {
-        a
-    } else {
-        b
-    }
-}
+use crate::linux::cgroup::Driver;
 
 /// `crate::check()` on linux
 pub fn check(settings: &crate::linux::Settings, res: &mut crate::check::CheckResult) {
     if !pidfd_supported() {
         res.warning("PID file descriptors not supported")
     }
-    let cgroup_info = CgroupVersion::detect(&settings.cgroupfs);
-    let cgroup_info = match cgroup_info {
-        Ok(inf) => inf,
-        Err(err) => {
-            res.error(&format!("Cgroupfs not detected: {}", err));
-            return;
-        }
-    };
-    if cgroup_info.0 == CgroupVersion::V1 {
-        if unsafe { libc::geteuid() } != 0 {
-            res.error("Root is required to use legacy cgroups");
-        }
-        return;
-    }
-
-    let sandbox_group = get_sandbox_chgroup_path(settings);
-    let current_group = get_current_cgroup_path();
-    let lca = find_lca(&sandbox_group, &current_group);
-    for group in &[&sandbox_group, lca] {
-        if let Err(msg) = check_has_cgroup_access(&group) {
-            res.error(&format!("Access denied to cgroup {:?}: {}", group, msg));
-        }
+    if let Err(err) = Driver::new(settings) {
+        res.error(&format!("Cgroup failure: {:#}", err));
     }
 }
 

--- a/src/linux/error.rs
+++ b/src/linux/error.rs
@@ -1,3 +1,5 @@
+use crate::linux::cgroup::{CgroupDetectionError, CgroupError};
+
 #[derive(Eq, PartialEq)]
 pub enum ErrorKind {
     /// This error typically means that isolated process tried to break its sandbox
@@ -16,14 +18,22 @@ pub enum Error {
     #[error("io error")]
     Io {
         #[from]
-        source: std::io::Error,
+        cause: std::io::Error,
     },
     #[error("sandbox interaction failed")]
     Sandbox,
     #[error("unknown error")]
     Unknown,
     #[error("Cgroup detection failure")]
-    Cgroups,
+    CgroupDetection {
+        #[from]
+        cause: CgroupDetectionError,
+    },
+    #[error("Cgroup manipulation failed")]
+    Cgroup {
+        #[from]
+        cause: CgroupError,
+    },
 }
 
 impl Error {
@@ -34,7 +44,8 @@ impl Error {
             Error::Io { .. } => ErrorKind::System,
             Error::Sandbox => ErrorKind::Sandbox,
             Error::Unknown => ErrorKind::System,
-            Error::Cgroups => ErrorKind::System,
+            Error::Cgroup { .. } => ErrorKind::System,
+            Error::CgroupDetection { .. } => ErrorKind::System,
         }
     }
 

--- a/src/linux/sandbox.rs
+++ b/src/linux/sandbox.rs
@@ -107,13 +107,13 @@ impl Sandbox for LinuxSandbox {
 
     fn kill(&self) -> Result<(), Error> {
         jail_common::kill_sandbox(self.0.zygote_pid, &self.0.id, &self.0.cgroup_driver)
-            .map_err(|err| Error::Io { source: err })?;
+            .map_err(|err| Error::Io { cause: err })?;
         Ok(())
     }
 
     fn resource_usage(&self) -> Result<crate::ResourceUsageData, Error> {
-        let cpu_usage = self.0.cgroup_driver.get_cpu_usage(&self.0.id);
-        let memory_usage = self.0.cgroup_driver.get_memory_usage(&self.0.id);
+        let cpu_usage = self.0.cgroup_driver.get_cpu_usage(&self.0.id)?;
+        let memory_usage = self.0.cgroup_driver.get_memory_usage(&self.0.id)?;
         Ok(crate::ResourceUsageData {
             memory: memory_usage,
             time: Some(cpu_usage),


### PR DESCRIPTION
Now we just try to instantiate CgroupDriver for different configuratins.
We then select first working config.
This is more reliable approach.

System check is also rewritten.
Now it just checks if Driver can be created.