### PR TITLE
Update shared items config

### DIFF
--- a/minion-tests/src/worker.rs
+++ b/minion-tests/src/worker.rs
@@ -21,10 +21,11 @@ async fn inner_main(test_cases: &[&'static dyn TestCase]) {
         max_alive_process_count: test_case.process_count_limit(),
         memory_limit: MEMORY_LIMIT_IN_BYTES,
         isolation_root: tempdir.path().to_path_buf(),
-        exposed_paths: vec![minion::SharedDir {
+        shared_items: vec![minion::SharedItem {
+            id: None,
             src: std::env::current_exe().unwrap(),
             dest: "/me".into(),
-            kind: minion::SharedDirKind::Readonly,
+            kind: minion::SharedItemKind::Readonly,
         }],
     };
     let sandbox = backend.new_sandbox(opts).expect("can not create sandbox");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,18 +51,21 @@ pub use command::Command;
 ///
 /// Warning: this type is __unstable__ (i.e. not covered by SemVer) and __non-portable__
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum SharedDirKind {
+pub enum SharedItemKind {
     Readonly,
     Full,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SharedDir {
+pub struct SharedItem {
+    /// Optional identifier.
+    /// It can be used to provide additional backend-specific settings.
+    pub id: Option<String>,
     /// Path on system
     pub src: PathBuf,
     /// Path for child
     pub dest: PathBuf,
-    pub kind: SharedDirKind,
+    pub kind: SharedItemKind,
 }
 
 /// This struct is returned by `Sandbox::resource_usage`
@@ -86,7 +89,7 @@ pub struct SandboxOptions {
     /// Specifies total wall-clock timer limit for whole sandbox
     pub real_time_limit: Duration,
     pub isolation_root: PathBuf,
-    pub exposed_paths: Vec<SharedDir>,
+    pub shared_items: Vec<SharedItem>,
 }
 
 impl SandboxOptions {
@@ -99,11 +102,11 @@ impl SandboxOptions {
     }
 
     fn postprocess(&mut self) {
-        let mut paths = std::mem::replace(&mut self.exposed_paths, Vec::new());
+        let mut paths = std::mem::replace(&mut self.shared_items, Vec::new());
         for x in &mut paths {
             x.dest = self.make_relative(&x.dest).to_path_buf();
         }
-        std::mem::swap(&mut paths, &mut self.exposed_paths);
+        std::mem::swap(&mut paths, &mut self.shared_items);
     }
 }
 

--- a/src/linux/jail_common.rs
+++ b/src/linux/jail_common.rs
@@ -1,4 +1,4 @@
-use crate::{linux::util::Pid, SharedDir};
+use crate::{linux::util::Pid, SharedItem};
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use std::{ffi::OsString, os::unix::io::RawFd, path::PathBuf, time::Duration};
@@ -14,7 +14,7 @@ pub(crate) struct JailOptions {
     /// Possible value: time_limit * 3.
     pub(crate) real_time_limit: Duration,
     pub(crate) isolation_root: PathBuf,
-    pub(crate) exposed_paths: Vec<SharedDir>,
+    pub(crate) shared_items: Vec<SharedItem>,
     pub(crate) jail_id: String,
     pub(crate) watchdog_chan: RawFd,
     pub(crate) allow_mount_ns_failure: bool,

--- a/src/linux/sandbox.rs
+++ b/src/linux/sandbox.rs
@@ -171,7 +171,7 @@ impl LinuxSandbox {
             cpu_time_limit: options.cpu_time_limit,
             real_time_limit: options.real_time_limit,
             isolation_root: options.isolation_root.clone(),
-            exposed_paths: options.exposed_paths.clone(),
+            shared_items: options.shared_items.clone(),
             jail_id: jail_id.clone(),
             watchdog_chan: write_end,
             allow_mount_ns_failure: settings.allow_unsupported_mount_namespace,

--- a/src/linux/zygote/setup.rs
+++ b/src/linux/zygote/setup.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         Error,
     },
-    SharedDir, SharedDirKind,
+    SharedItem, SharedItemKind,
 };
 use nix::sys::signal;
 use std::{
@@ -49,7 +49,7 @@ fn configure_dir(dir_path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-fn expose_dir(jail_root: &Path, system_path: &Path, alias_path: &Path, kind: SharedDirKind) {
+fn expose_item(jail_root: &Path, system_path: &Path, alias_path: &Path, kind: SharedItemKind) {
     let bind_target = jail_root.join(alias_path);
     fs::create_dir_all(&bind_target).unwrap();
     let stat = fs::metadata(&system_path)
@@ -72,7 +72,7 @@ fn expose_dir(jail_root: &Path, system_path: &Path, alias_path: &Path, kind: Sha
             err_exit("mount");
         }
 
-        if let SharedDirKind::Readonly = kind {
+        if let SharedItemKind::Readonly = kind {
             let rem_ret = libc::mount(
                 ptr::null(),
                 bind_target.as_ptr(),
@@ -87,10 +87,10 @@ fn expose_dir(jail_root: &Path, system_path: &Path, alias_path: &Path, kind: Sha
     }
 }
 
-pub(crate) fn expose_dirs(expose: &[SharedDir], jail_root: &Path) {
+pub(crate) fn expose_items(expose: &[SharedItem], jail_root: &Path) {
     // mount --bind
     for x in expose {
-        expose_dir(jail_root, &x.src, &x.dest, x.kind.clone())
+        expose_item(jail_root, &x.src, &x.dest, x.kind.clone())
     }
 }
 
@@ -183,7 +183,7 @@ fn setup_time_watch(
 }
 
 fn setup_expositions(options: &JailOptions) {
-    expose_dirs(&options.exposed_paths, &options.isolation_root);
+    expose_items(&options.shared_items, &options.isolation_root);
 }
 
 fn setup_panic_hook() {


### PR DESCRIPTION
- Make naming more consistent
- Add a name parameter (it can be later used in a
backend-specific configuration)